### PR TITLE
バフトリックの仕様を変更しました

### DIFF
--- a/Big Wave prototype/Assets/Prefab/PlayerBuffStockGaugeInside.prefab
+++ b/Big Wave prototype/Assets/Prefab/PlayerBuffStockGaugeInside.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &193812624958497627
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4110505482660452302}
+  - component: {fileID: 4868298938825369286}
+  - component: {fileID: 1109764895407382671}
+  m_Layer: 5
+  m_Name: PlayerBuffStockGaugeInside
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4110505482660452302
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 193812624958497627}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -41.3, y: -1.25}
+  m_SizeDelta: {x: 17.6, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4868298938825369286
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 193812624958497627}
+  m_CullTransparentMesh: 1
+--- !u!114 &1109764895407382671
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 193812624958497627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.23553032, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4a3a6c5209472274eadabc41d2e61730, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Big Wave prototype/Assets/Prefab/PlayerBuffStockGaugeInside.prefab.meta
+++ b/Big Wave prototype/Assets/Prefab/PlayerBuffStockGaugeInside.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8364cf8f5d8037f4bbcc209099f64f55
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Big Wave prototype/Assets/Scenes/SampleScene.unity
+++ b/Big Wave prototype/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028352, g: 0.22571376, b: 0.30692244, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -577,6 +577,144 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 126
   m_CollisionDetection: 0
+--- !u!1 &119033915
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 119033916}
+  - component: {fileID: 119033918}
+  - component: {fileID: 119033917}
+  m_Layer: 5
+  m_Name: PlayerBuffStockText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &119033916
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 119033915}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.602653, y: 0.6596084, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1063896220}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -328.16, y: 61.8}
+  m_SizeDelta: {x: 327, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &119033917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 119033915}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'BUFF
+
+    STOCK
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &119033918
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 119033915}
+  m_CullTransparentMesh: 1
 --- !u!1 &138943755
 GameObject:
   m_ObjectHideFlags: 0
@@ -2906,6 +3044,7 @@ RectTransform:
   - {fileID: 1041760309}
   - {fileID: 1377110172}
   - {fileID: 435669033}
+  - {fileID: 1063896220}
   - {fileID: 544838415}
   - {fileID: 1513945113}
   - {fileID: 2042907975}
@@ -4278,6 +4417,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1044993408}
   m_CullTransparentMesh: 1
+--- !u!1 &1063896219
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1063896220}
+  m_Layer: 5
+  m_Name: PlayerBuffStock
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1063896220
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063896219}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 119033916}
+  - {fileID: 2025281100}
+  m_Father: {fileID: 651057539}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1110614296
 GameObject:
   m_ObjectHideFlags: 0
@@ -4840,8 +5016,7 @@ MonoBehaviour:
     trickSound: {fileID: 8300000, guid: c79ceaca2c1ed324bbcefe4432715176, type: 3}
   damageAmount: 100
   healAmount: 50
-  powerUpBuff: 1
-  chargeTrickBuff: 1
+  trickBoostBuff: 1
   hoverTime: 0.05
   hoverJumpStrength: 12
 --- !u!108 &1244729536
@@ -5118,16 +5293,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4d01bfc928202a24a9d7648fc1b00e93, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  powerUp:
-    buffTime: 5
+  trickBoost:
+    buffStockMax: 6
     effect: {fileID: 1503523459}
     effectShow: 1
-    growthRate: 2
-  chargeTrick:
-    buffTime: 5
-    effect: {fileID: 1720416255}
-    effectShow: 1
-    growthRate: 2
+    growthRate: 20
 --- !u!114 &1244729544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12107,6 +12277,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1940460168}
   m_CullTransparentMesh: 1
+--- !u!1 &2025281099
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2025281100}
+  - component: {fileID: 2025281102}
+  - component: {fileID: 2025281101}
+  m_Layer: 5
+  m_Name: PlayerBuffStockGaugeOutside
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2025281100
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025281099}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1063896220}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -282, y: 64.599976}
+  m_SizeDelta: {x: 151, y: 16.4}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2025281101
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025281099}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.05660379, g: 0.05660379, b: 0.05660379, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2025281102
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025281099}
+  m_CullTransparentMesh: 1
 --- !u!1 &2042907974
 GameObject:
   m_ObjectHideFlags: 0
@@ -12296,6 +12541,10 @@ MonoBehaviour:
   feverGaugeOfPlayer: {fileID: 1248422115}
   feverGaugeNormalColor: {r: 0.5733415, g: 0, b: 0.5924529, a: 1}
   feverGaugeFeverModeColor: {r: 1, g: 0.5566037, b: 0.9295539, a: 1}
+  outOfBuffStockGaugeOfPlayer: {fileID: 2025281099}
+  buffStockGaugeOfPlayer: {fileID: 193812624958497627, guid: 8364cf8f5d8037f4bbcc209099f64f55, type: 3}
+  buffStockGaugeInterval: 8
+  buffStockedGaugeColor: {r: 1, g: 0, b: 0, a: 1}
   hpGaugeOfEnemy: {fileID: 207016421}
 --- !u!114 &2119914098
 MonoBehaviour:

--- a/Big Wave prototype/Assets/Script/EtcScript/StatusDisplay.cs
+++ b/Big Wave prototype/Assets/Script/EtcScript/StatusDisplay.cs
@@ -32,6 +32,18 @@ public class StatusDisplay : MonoBehaviour
     [Header("▼フィーバー状態のフィーバーゲージの色")]
     [SerializeField] Color feverGaugeFeverModeColor;//フィーバー状態のフィーバーゲージの色
 
+    //プレイヤーのバフストック関連
+    [Header("▼バフのストック数を表すゲージの黒い部分")]
+    [SerializeField] GameObject outOfBuffStockGaugeOfPlayer;//バフのストック数を表すゲージの黒い部分
+    [Header("▼バフのストック数を表すゲージ")]
+    [SerializeField] GameObject buffStockGaugeOfPlayer;//バフのストック数を表すゲージ
+    [Header("▼分割されたバフストックゲージをどれくらい離すか")]
+    [SerializeField] float buffStockGaugeInterval;//分割されたバフストックゲージをどれくらい離すか
+    [Header("▼満タン状態のトリックゲージの色")]
+    [SerializeField] Color buffStockedGaugeColor;//ストック状態のバフストックゲージの色
+    private GameObject[] buffStockGauges;//プレイヤーのバフストックゲージ(内部処理用)
+
+
     //敵のHP関連
     [Header("▼敵のHPゲージ")]
     [SerializeField] GameObject hpGaugeOfEnemy;//敵のHPゲージ
@@ -39,6 +51,7 @@ public class StatusDisplay : MonoBehaviour
     Enemy enemy;
     Player player;
     ProcessFeverMode processFeverPoint;
+    BuffOfPlayer buffOfPlayer;
 
     // Start is called before the first frame update
     void Start()
@@ -46,10 +59,16 @@ public class StatusDisplay : MonoBehaviour
         player = GameObject.FindWithTag("Player").GetComponent<Player>();
         enemy = GameObject.FindWithTag("Enemy").GetComponent<Enemy>();
         processFeverPoint= GameObject.FindWithTag("Player").GetComponent<ProcessFeverMode>();
+        buffOfPlayer = GameObject.FindWithTag("Player").GetComponent<BuffOfPlayer>();
         //トリックゲージの生成(ゲージ数個分)
         GenerateTrickGauge();
         //トリックゲージの位置調整
         PositioningTrickGauge();
+
+        //バフストックゲージの生成(ゲージ数個分)
+        GenerateBuffStockGauge();
+        //バフストックゲージの位置調整    
+        PositioningBuffStockGauge();
     }
 
     // Update is called once per frame
@@ -62,6 +81,8 @@ public class StatusDisplay : MonoBehaviour
         FeverGaugeOfPlayer();//プレイヤーのフィーバーゲージの処理
 
         HPGaugeOfEnemy();//敵のHPゲージの処理
+
+        BuffStockGaugeOfPlayer();//プレイヤーのバフストックゲージの処理
     }
 
     //プレイヤーのHP関係のメソッド
@@ -156,6 +177,73 @@ public class StatusDisplay : MonoBehaviour
             feverGaugeOfPlayer.GetComponent<Image>().color = feverGaugeNormalColor;
         }
     }
+
+    //プレイヤーのバフストック関係のメソッド
+    void GenerateBuffStockGauge()
+    {
+        buffStockGauges = new GameObject[buffOfPlayer.TrickBoost.BuffStockMax];
+
+        for (int i = 0; i < buffStockGauges.Length; i++)
+        {
+            buffStockGauges[i] = Instantiate(buffStockGaugeOfPlayer,
+                outOfBuffStockGaugeOfPlayer.transform);
+        }
+    }
+
+    void PositioningBuffStockGauge()//バフストックゲージの位置調整
+    {
+        //黒い部分のバフストックゲージの(横の)大きさを取得
+        Vector2 sd_OutOfBuffStockGauge = outOfBuffStockGaugeOfPlayer.GetComponent<RectTransform>().sizeDelta;
+        //分割されているバフストックゲージの大きさを決める(全て同じ大きさ)
+        Vector2 sd_BuffStockGauge = buffStockGauges[0].GetComponent<RectTransform>().sizeDelta;
+        sd_BuffStockGauge.x = (sd_OutOfBuffStockGauge.x - (buffStockGauges.Length - 1) * buffStockGaugeInterval) / buffStockGauges.Length;
+        sd_BuffStockGauge.y = sd_OutOfBuffStockGauge.y;
+
+        //分割されているバフストックゲージの大きさと位置を変更
+        for (int i = 0; i < buffStockGauges.Length; i++)
+        {
+            //大きさを変更
+            buffStockGauges[i].GetComponent<RectTransform>().sizeDelta = sd_BuffStockGauge;
+            //位置を変更
+            Vector3 pos_BuffStockGauge;
+            pos_BuffStockGauge = buffStockGauges[i].GetComponent<RectTransform>().anchoredPosition3D;
+
+            //一つ目のゲージは左端のどこに置くかを決める
+            if (i == 0)
+            {
+                pos_BuffStockGauge.x = -sd_OutOfBuffStockGauge.x / 2 + sd_BuffStockGauge.x / 2;
+            }
+            //それ以降のゲージは前に置いたゲージと一定間隔で置く
+            else
+            {
+                Vector3 pos_BeforeBuffStockGauge = buffStockGauges[i - 1].GetComponent<RectTransform>().anchoredPosition3D;
+                pos_BuffStockGauge.x = pos_BeforeBuffStockGauge.x + sd_BuffStockGauge.x + buffStockGaugeInterval;
+            }
+
+            pos_BuffStockGauge.y = 0;
+            buffStockGauges[i].GetComponent<RectTransform>().anchoredPosition3D = pos_BuffStockGauge;
+        }
+    }
+
+    void BuffStockGaugeOfPlayer()//プレイヤーのバフストックゲージの処理
+    {
+        int buffStockCount = buffOfPlayer.TrickBoost.BuffStockCount;
+
+        for (int i = 0; i < buffStockGauges.Length; i++)
+        {
+            if (i < buffStockCount)
+            {
+                buffStockGauges[i].GetComponent<Image>().color = buffStockedGaugeColor;
+            }
+
+            else
+            {
+                buffStockGauges[i].GetComponent<Image>().color = Color.clear;
+            }
+        }
+    }
+
+
 
 
     //敵のHP関係のメソッド

--- a/Big Wave prototype/Assets/Script/PlayerScript/BuffOfPlayer.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/BuffOfPlayer.cs
@@ -6,18 +6,26 @@ using UnityEngine;
 [System.Serializable]
 public class Buff//バフ(基本的にこれを継承してバフを作る)
 {
-    [Header("効果時間(秒)")]
-    [SerializeField] float buffTime = 5f;//バフの効果時間(秒)
+    //[Header("効果時間(秒)")]
+    //[SerializeField] float buffTime = 5f;//バフの効果時間(秒)
+    [Header("バフの最大ストック数")]
+    [SerializeField] int buffStockMax = 6;//バフの最大ストック数
     [Header("バフのエフェクト")]
     [SerializeField] GameObject effect;//バフのエフェクト
     [Header("バフのエフェクトを表示するか")]
     [SerializeField] bool effectShow = true;
-    private float buffRemainingTime = 0f;//バフの残り効果時間(秒)、これが0秒以下になったらバフの効果が切れるようにする
+    //private float buffRemainingTime = 0f;//バフの残り効果時間(秒)、これが0秒以下になったらバフの効果が切れるようにする
+    private int buffStockCount = 0;//バフの残りストック数
     protected bool activateNow = false;//バフ効果発動中か
 
-    public float BuffTime
+    /*public float BuffTime
     {
         get { return buffTime; }
+    }*/
+
+    public int BuffStockMax
+    {
+        get { return buffStockMax; }
     }
 
     public GameObject Effect
@@ -25,9 +33,14 @@ public class Buff//バフ(基本的にこれを継承してバフを作る)
         get { return effect; }
     }
 
-    public float BuffRemainingTime
+    /*public float BuffRemainingTime
     {
         get { return buffRemainingTime; }
+    }*/
+
+    public int BuffStockCount
+    {
+        get { return buffStockCount; }
     }
 
     public bool ActivateNow
@@ -37,23 +50,33 @@ public class Buff//バフ(基本的にこれを継承してバフを作る)
 
     public Buff()
     {
-        buffRemainingTime = 0f;
+        //buffRemainingTime = 0f;
+        buffStockCount = 0;
         activateNow = false;
     }
 
     //バフの残り効果時間の処理とバフ効果の処理
     public void ProcessBuffEffect()
     {
-        BuffEffectTime();
+        //BuffEffectTime();
+        BuffEffectCount();
         BuffEffect();
     }
 
     //バフの残り効果時間の処理
-    void BuffEffectTime()
+    /*void BuffEffectTime()
     {
         buffRemainingTime-=Time.deltaTime;
 
         if(buffRemainingTime<=0f)//バフ効果切れ
+        {
+            activateNow = false;
+        }
+    }*/
+
+    void BuffEffectCount()
+    {
+        if(buffStockCount <= 0)//ストックがないなら
         {
             activateNow = false;
         }
@@ -79,14 +102,40 @@ public class Buff//バフ(基本的にこれを継承してバフを作る)
     public void Activate()
     {
         activateNow=true;//バフ効果発動中にする
-        buffRemainingTime = buffTime;
+        //buffRemainingTime = buffTime;
     }
 
     //バフを消す
     public void Deactivate()
     {
         activateNow=false;
-        buffRemainingTime = 0f;
+        //buffRemainingTime = 0f;
+    }
+
+    public void IncreaseBuffStock()
+    {
+        if(buffStockCount < buffStockMax)//バフストック数が最大値未満なら
+        {
+            buffStockCount++;//バフストックを1増やす
+        }
+
+        else
+        {
+            return;
+        }
+    }
+
+    public void DecrementBuffStock()
+    {
+        if(buffStockCount > 0)//バフストックがあるなら
+        {
+            buffStockCount--;//バフストックを1減らす
+        }
+
+        else
+        {
+            return;
+        }
     }
 }
 
@@ -130,12 +179,14 @@ public class UpBuff : Buff//増加系のバフ
 
 public class BuffOfPlayer : MonoBehaviour
 {
-    [Header("攻撃力アップのバフ")]
+    /*[Header("攻撃力アップのバフ")]
     [SerializeField] UpBuff powerUp;//攻撃力アップのバフ
     [Header("チャージトリック増加のバフ")]
-    [SerializeField] UpBuff chargeTrick;//チャージトリック増加のバフ
+    [SerializeField] UpBuff chargeTrick;//チャージトリック増加のバフ*/
+    [Header("トリック強化のバフ")]
+    [SerializeField] UpBuff trickBoost;//トリック強化のバフ
 
-    public UpBuff PowerUp
+    /*public UpBuff PowerUp
     {
         get { return powerUp; }
     }
@@ -143,23 +194,31 @@ public class BuffOfPlayer : MonoBehaviour
     public UpBuff ChargeTrick
     {
         get { return chargeTrick; }
+    }*/
+
+    public UpBuff TrickBoost
+    {
+        get { return trickBoost; }
     }
 
     // Start is called before the first frame update
     void Start()
     {
-        powerUp.Effect.SetActive(false);
-        chargeTrick.Effect.SetActive(false);
+        //powerUp.Effect.SetActive(false);
+        //chargeTrick.Effect.SetActive(false);
+        trickBoost.Effect.SetActive(false);
     }
 
     // Update is called once per frame
     void Update()
     {
-        //攻撃力アップバフ
+        /*//攻撃力アップバフ
         powerUp.ProcessBuffEffect();
 
         //チャージトリック量増加バフ
-        chargeTrick.ProcessBuffEffect();
+        chargeTrick.ProcessBuffEffect();*/
+
+        trickBoost.ProcessBuffEffect();
     }
 
    

--- a/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickFromWaveControl.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickFromWaveControl.cs
@@ -66,7 +66,7 @@ public class ChargeTrickFromWaveControl : MonoBehaviour
 
     float ChargeTrickAmount(float b)//チャージされるトリック量(bにはinSideChargeTrickかoutSideChargeTrickが入る)
     {
-        return b * buffOfPlayer.ChargeTrick.CurrentGrowthRate * processFeverPoint.CurrentChargeTrick_GrowthRate * chargeRate[player.MaxCount];
+        return b * /*buffOfPlayer.ChargeTrick.CurrentGrowthRate **/ processFeverPoint.CurrentChargeTrick_GrowthRate * chargeRate[player.MaxCount];
     }
 
     //波に触れてトリックをチャージするときの内部の処理

--- a/Big Wave prototype/Assets/Script/PlayerScript/TrickControl.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/TrickControl.cs
@@ -51,10 +51,12 @@ public class TrickControl : MonoBehaviour
     [SerializeField] float damageAmount = 100;//通常時の敵に与えるダメージ
     [Header("HPの回復量")]
     [SerializeField] float healAmount = 50;//HPの回復量
-    [Header("攻撃力増加のバフ")]
+    /*[Header("攻撃力増加のバフ")]
     [SerializeField] bool powerUpBuff=false;//攻撃力増加のバフ
     [Header("チャージトリック量増加のバフ")]
-    [SerializeField] bool chargeTrickBuff=false;//チャージトリック量増加のバフ
+    [SerializeField] bool chargeTrickBuff=false;//チャージトリック量増加のバフ*/
+    [Header("トリック強化のバフ")]
+    [SerializeField] bool trickBoostBuff = false;//トリック強化のバフ
     //[SerializeField] float trick_DamageFactor = 0.5f;//トリックをためた時のダメージの上昇具合、1、２、3、nだとそれぞれトリック満タン時、トリック空っぽの時のダメージの2、3、4、(1+1*n)倍になる
     [Header("トリック使用時の滞空時間")]
     [SerializeField] float hoverTime = 0.2f;//トリック使用時の滞空時間
@@ -62,7 +64,9 @@ public class TrickControl : MonoBehaviour
     [SerializeField] float hoverJumpStrength = 2f;//滞空終了時に起こるジャンプの強さ
     private bool tricked;//トリックしたかしていないかの判定
     private int trickCount=0;//一回のジャンプにしたトリックの回数
+    private bool consumedTrickPoint;//トリックゲージを消費したかどうかの判定
     private Coroutine HoverCoroutine;
+
     AudioSource audioSource;//プレイヤーから音を出す為の処置。
     Enemy enemy;
     Player player;
@@ -108,47 +112,77 @@ public class TrickControl : MonoBehaviour
 
     float Damage()//敵に与えるダメージ合計
     {
-        return damageAmount * buffOfPlayer.PowerUp.CurrentGrowthRate * processFeverPoint.CurrentPowerUp_GrowthRate;
+        //return damageAmount * buffOfPlayer.PowerUp.CurrentGrowthRate * processFeverPoint.CurrentPowerUp_GrowthRate;
+        return damageAmount* buffOfPlayer.TrickBoost.CurrentGrowthRate * processFeverPoint.CurrentPowerUp_GrowthRate;
+    }
+
+    float Heal()
+    {
+        return healAmount * buffOfPlayer.TrickBoost.CurrentGrowthRate;
     }
 
 
     //トリック
     void Trick(Trick trick)
     {
-        if (jumpcontrol.JumpNow == true && player.ConsumeTrickPoint(trick.TrickCost) && enemy != null)//ジャンプしている＆消費トリックが足りる(ここでトリック消費の処理をする)＆敵がいる時のみ攻撃可能
+        if (jumpcontrol.JumpNow == true && /*player.ConsumeTrickPoint(trick.TrickCost) &&*/ enemy != null)//ジャンプしている＆消費トリックが足りる(ここでトリック消費の処理をする)＆敵がいる時のみ攻撃可能
         {
+            consumedTrickPoint = false;
 
-            switch (trick.TrickPattern)
+            if(trick.TrickPattern == TrickType.buff
+                && buffOfPlayer.TrickBoost.BuffStockCount >= buffOfPlayer.TrickBoost.BuffStockMax)
+            //バフのトリックが行われ、かつバフのストックが最大数たまっているなら
             {
-                case TrickType.attack://敵にダメージを与える
-                    
-                    enemy.Hp -= Damage();
-                    break;
-                case TrickType.heal://プレイヤーの体力を回復する
-                    player.Hp += healAmount;
-                    break;
-                case TrickType.buff://プレイヤーにバフをかける
-                    if (powerUpBuff)
-                    {
-                        buffOfPlayer.PowerUp.Activate();
-                    }
-                    if (chargeTrickBuff)
-                    {
-                        buffOfPlayer.ChargeTrick.Activate();
-                    }
-                    break;
+                return;//トリックの処理を行わない
             }
 
-            //全てのトリックの共通処理
-            tricked = true;//トリックした
-            controller.Vibe_Trick();//バイブさせる
-            //☆福島君が書いた
-            audioSource.PlayOneShot(trick.TrickSound);//効果音の再生
-            //
-            managementOfScore.AddTrickScore();//トリック成功によるスコアの加点
-            trickCount++;//1回トリックした(1ジャンプ中に)
-            processFeverPoint.ChargeFeverPoint(trickCount);
-            HoverCoroutine = StartCoroutine(HoverJump());
+            if (player.ConsumeTrickPoint(trick.TrickCost))
+            {
+                consumedTrickPoint = true;
+
+                switch (trick.TrickPattern)
+                {
+                    case TrickType.attack://敵にダメージを与える
+                        buffOfPlayer.TrickBoost.DecrementBuffStock();
+                        enemy.Hp -= Damage();
+                        break;
+                    case TrickType.heal://プレイヤーの体力を回復する
+                        buffOfPlayer.TrickBoost.DecrementBuffStock();
+                        //player.Hp += healAmount;
+                        player.Hp += Heal();
+                        break;
+                    case TrickType.buff://プレイヤーにバフをかける
+                        /*if (powerUpBuff)
+                        {
+                            buffOfPlayer.PowerUp.Activate();
+                        }
+                        if (chargeTrickBuff)
+                        {
+                            buffOfPlayer.ChargeTrick.Activate();
+                        }*/
+
+                        if(trickBoostBuff)
+                        {
+                            buffOfPlayer.TrickBoost.IncreaseBuffStock();//バフストック数の増加
+                            buffOfPlayer.TrickBoost.Activate();
+                        }
+                        break;
+                }
+            }
+
+            if (consumedTrickPoint)
+            {
+                //全てのトリックの共通処理
+                tricked = true;//トリックした
+                controller.Vibe_Trick();//バイブさせる
+                                        //☆福島君が書いた
+                audioSource.PlayOneShot(trick.TrickSound);//効果音の再生
+                                                          //
+                managementOfScore.AddTrickScore();//トリック成功によるスコアの加点
+                trickCount++;//1回トリックした(1ジャンプ中に)
+                processFeverPoint.ChargeFeverPoint(trickCount);
+                HoverCoroutine = StartCoroutine(HoverJump());
+            }
         }
     }
 


### PR DESCRIPTION
以下のスクリプトにコードの追加や変更を行いました。
・TrickControl
    　トリックゲージを消費する処理を行う前に、バフストック数が最大の時にバフのトリックが行われたかどうか判定する処理　
　を実装し、判定結果に応じてトリックの処理を行わないようにしました。

・BuffOfPlayer
　攻撃力上昇、トリックゲージチャージ量上昇のバフをコメントアウトし、トリック強化のバフを追加しました。
　また、バフストック数を管理する関数を追加しました。

・StatusDisplay
　バフのストック数を表すゲージを表示するコードを追加しました。

・ChargeTrickFromWaveControl
　チャージ量上昇のバフがなくなったことに伴い、チャージ量上昇バフによる倍率効果をコメントアウトしました。

バフストックゲージに関するUIを追加しました。

コードの書き方について前より複雑になってしまった部分があるので、良い案があったら教えてもらえるか修正していただけるとありがたいです。
バグはないことを確認しましたが、変更箇所が多いので不具合があったら教えてください。

すみません！　バフ適用時の強化倍率を1から20に変更したままでした！