### PR TITLE
スクリプトの整理

### DIFF
--- a/Big Wave prototype/Assets/Scenes/SampleScene.unity
+++ b/Big Wave prototype/Assets/Scenes/SampleScene.unity
@@ -4942,7 +4942,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   chargeEffect: {fileID: 1722439556}
-  maxScale: 0.2
+  maxScaleRate: 4
 --- !u!114 &1244729550
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4969,8 +4969,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   chargeRateMax: 3
-  byRateMaxTime: 10
-  minusChargeRateSpeed: 0
+  maxRateTime: 10
+  minusChargeRateSpeed: 2
 --- !u!114 &1244729552
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickScript/ChangeChargeTrickTheSurfer.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickScript/ChangeChargeTrickTheSurfer.cs
@@ -75,9 +75,4 @@ public class ChangeChargeTrickTheSurfer : MonoBehaviour
 
         currentChargeRate = Mathf.Clamp(currentChargeRate, 1, chargeRateMax);
     }
-
-    public float RatioOfChargeRate()//
-    {
-        return (currentChargeRate-normalChargeRate) / (chargeRateMax-normalChargeRate);
-    }
 }

--- a/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickScript/ChangeChargeTrickTheSurfer.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickScript/ChangeChargeTrickTheSurfer.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.InteropServices.WindowsRuntime;
 using UnityEngine;
 
 //™ì¬Ò:™R
@@ -9,16 +10,15 @@ public class ChangeChargeTrickTheSurfer : MonoBehaviour
     [Header("Å‘å‚Ü‚Å‚½‚Ü‚è‚â‚·‚­‚È‚Á‚½‚Ì”{—¦(Å‘å”{—¦)")]
     [SerializeField] float chargeRateMax=1;//Å‘å”{—¦
     [Header("Å‘å”{—¦‚É‚È‚é‚Ü‚Å‚É‚©‚©‚éŠÔ")]
-    [SerializeField] float byRateMaxTime=10;//Å‘å”{—¦‚É‚È‚é‚Ü‚Å‚É‚©‚©‚éŠÔ
+    [SerializeField] float byMaxRateTime=10;//Å‘å”{—¦‚É‚È‚é‚Ü‚Å‚É‚©‚©‚éŠÔ
     [Header("”{—¦‚ªŒ¸‚é‘¬“x(”{—¦‚ª‘‚¦‚é‚Ì‘¬“x‚ğ1‚Æ‚µ‚Ä)")]
     [SerializeField] float minusChargeRateSpeed;//”g‚ÉG‚ê‚Ä‚È‚¢‚©‚ÂƒWƒƒƒ“ƒv‚µ‚Ä‚¢‚È‚¢‚É”{—¦‚ªŒ¸‚é‘¬“x
-    private float curremtChangeChargeRateTime=0;//”{—¦‚ª•Ï‰»‚µ‚Ä‚¢‚éŠÔ
     private const float normalChargeRate = 1;//“™”{
     private float currentChargeRate = normalChargeRate;//Œ»İ‚Ì”{—¦
+    private float changeRatePerSecond;//1•b‚²‚Æ‚É‘‚¦‚é”{—¦—Ê
 
     JumpControl jumpControl;
     JudgeTouchWave judgeTouchWave;
-    ChangeChargeTrickTheSurferEffect changeChargeTrickEffect;
 
     public float CurrentChargeRate
     {
@@ -30,12 +30,18 @@ public class ChangeChargeTrickTheSurfer : MonoBehaviour
         get { return chargeRateMax; }
     }
 
+    public float NormalChargeRate
+    {
+        get { return normalChargeRate; }
+    }
+
     // Start is called before the first frame update
     void Start()
     {
         jumpControl = GetComponent<JumpControl>();
         judgeTouchWave = GetComponent<JudgeTouchWave>();
-        changeChargeTrickEffect = GetComponent<ChangeChargeTrickTheSurferEffect>();
+
+        changeRatePerSecond = (chargeRateMax - normalChargeRate) / byMaxRateTime;
     }
 
     // Update is called once per frame
@@ -59,24 +65,19 @@ public class ChangeChargeTrickTheSurfer : MonoBehaviour
         //”g‚ÉG‚ê‚Ä‚¢‚é‚©ƒWƒƒƒ“ƒv‚µ‚Ä‚¢‚éAbyRateMaxTime‚©‚¯‚Ä‚¾‚ñ‚¾‚ñ”{—¦‚ª1”{‚©‚çchargeRateMax”{‚Ü‚Å•Ï‰»‚·‚é
         if (ChangeChargeRateNow())
         {
-            curremtChangeChargeRateTime += Time.deltaTime;
-            curremtChangeChargeRateTime = Mathf.Clamp(curremtChangeChargeRateTime, 0, byRateMaxTime);
+            currentChargeRate += changeRatePerSecond * Time.deltaTime;//1ƒtƒŒ[ƒ€‚²‚Æ‚É‘‚¦‚é”{—¦—Ê
         }
         //‚»‚¤‚Å‚È‚¢A”{—¦‚ªŠÔ‚²‚Æ‚ÉŒ¸‚Á‚Ä‚¢‚­
         else
         {
-            curremtChangeChargeRateTime -= minusChargeRateSpeed*Time.deltaTime;
-            curremtChangeChargeRateTime = Mathf.Clamp(curremtChangeChargeRateTime, 0, byRateMaxTime);
+            currentChargeRate -= minusChargeRateSpeed * changeRatePerSecond * Time.deltaTime;//1ƒtƒŒ[ƒ€‚²‚Æ‚ÉŒ¸‚é”{—¦—Ê
         }
 
-        currentChargeRate = normalChargeRate + (chargeRateMax - normalChargeRate) * RatioOfChargeRate();
         currentChargeRate = Mathf.Clamp(currentChargeRate, 1, chargeRateMax);
-
-        changeChargeTrickEffect.ChangeEffectScale();
     }
 
-    public float RatioOfChargeRate()
+    public float RatioOfChargeRate()//
     {
-        return curremtChangeChargeRateTime / byRateMaxTime;
+        return (currentChargeRate-normalChargeRate) / (chargeRateMax-normalChargeRate);
     }
 }

--- a/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickScript/ChangeChargeTrickTheSurferEffect.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickScript/ChangeChargeTrickTheSurferEffect.cs
@@ -6,41 +6,40 @@ public class ChangeChargeTrickTheSurferEffect : MonoBehaviour
 {
     [Header("チャージ時のエフェクト")]
     [SerializeField] GameObject chargeEffect;//チャージ時のエフェクト
-    [Header("最大倍率時のチャージ時のエフェクトの大きさ")]
-    [SerializeField] float maxScale;//チャージ時のエフェクト
-    private Vector3 normalScale;
-    private Vector3 currentScale;
+    [Header("最大倍率時のチャージ時のエフェクトの大きさ(倍率)")]
+    [SerializeField] float maxScaleRate;//最大倍率時のチャージ時のエフェクトの大きさ、初期の大きさから何倍の大きさか
+    private Vector3 maxScale;//最大倍率時のエフェクトの大きさ
+    private Vector3 normalScale;//通常時(初期)のエフェクトの大きさ
+    private Vector3 currentScale;//現在のエフェクトの大きさ
 
-    JudgeChargeNow judgeChargeNow;
     ChangeChargeTrickTheSurfer changeChargeTrickTheSurfer;
     // Start is called before the first frame update
     void Start()
     {
-        judgeChargeNow = GetComponent<JudgeChargeNow>();
         changeChargeTrickTheSurfer =GetComponent<ChangeChargeTrickTheSurfer>();
         normalScale = chargeEffect.transform.localScale;
+        maxScale = normalScale * maxScaleRate;
         currentScale = normalScale;
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+        ChangeEffectScale();//エフェクトの大きさを変更
     }
 
     public void ChangeEffectScale()//エフェクトの大きさを変更
     {
-        //エフェクトの大きさを変更
-        float effectScale = normalScale.x + (maxScale - normalScale.x) *changeChargeTrickTheSurfer.RatioOfChargeRate();
-        currentScale = new Vector3(effectScale, effectScale, effectScale);
-
-        ApplyCurrentScale();
-    }
-
-    void ApplyCurrentScale()//現在の大きさを適用
-    {
-        if(judgeChargeNow.ChargeNow())
+        if (chargeEffect.activeSelf)//チャージエフェクトがアクティブの時にエフェクトの大きさを変更
         {
+            float current = changeChargeTrickTheSurfer.CurrentChargeRate - changeChargeTrickTheSurfer.NormalChargeRate;//現在の倍率から通常の倍率(1)を引いたもの
+            float max = changeChargeTrickTheSurfer.ChargeRateMax - changeChargeTrickTheSurfer.NormalChargeRate;//最大倍率から通常の倍率(1)を引いたもの
+            float ratio= current / max;
+
+            //エフェクトの現在の大きさの値を変更
+            currentScale = normalScale + (maxScale - normalScale) * ratio;
+
+            //現在の大きさをエフェクトの大きさに適用
             chargeEffect.transform.localScale = currentScale;
         }
     }

--- a/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickScript/ChargeTrick.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/ChargeTrickScript/ChargeTrick.cs
@@ -52,10 +52,10 @@ public class ChargeTrick : MonoBehaviour
 
     float ChargeTrickAmount(float b)//チャージされるトリック量(bにはinSideChargeTrickかoutSideChargeTrickが入る)
     {
-        float ret=b;
+        float ret=b;//通常時のチャージされるトリック量
         ret *= processFeverPoint.CurrentChargeTrick_GrowthRate;//フィーバー状態のチャージ倍率
         ret *= changeChargeTrickTheCharger.ChargeRate();//満タンのトリックゲージの数によるチャージ倍率
-        ret*= changeChargeTrickTheSurfer.CurrentChargeRate;//波に乗っている時間によるチャージ倍率
+        ret *= changeChargeTrickTheSurfer.CurrentChargeRate;//波に乗っている時間によるチャージ倍率
         return ret;
     }
 


### PR DESCRIPTION
トリックのチャージ関連のスクリプトの整理をしました。
外部機能の変更点はChangeChargeTrickTheSurferEffectのエフェクトの最大倍率時の大きさ(scale)を指定するとき、以前は最大倍率時のエフェクトの大きさの値を指定しなければならなかったのを、通常時(初期)の大きさに対しての最大倍率時の大きさの倍率を指定する仕様に変更しました。(例えば最大倍率時初期の5倍の大きさになるようにしたい時は5を入力すればいい)