### PR TITLE
一部アニメーションの修正、クリティカルとフィーバーモードとenum型のスクリプトの修正、ホーミングミサイルのバグ修正

### DIFF
--- a/Big Wave prototype/Assets/Animation/Kuromakuro/Animation_kuromakuro.controller
+++ b/Big Wave prototype/Assets/Animation/Kuromakuro/Animation_kuromakuro.controller
@@ -352,6 +352,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &1802833807495768887
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Damage
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3550679612120925741}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.53125
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &2330390102412292261
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -418,6 +443,7 @@ AnimatorState:
   - {fileID: -2257600223836993338}
   - {fileID: 931863165348865060}
   - {fileID: -4306115901630280290}
+  - {fileID: 1802833807495768887}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Big Wave prototype/Assets/Animation/SURF/Animation_surf.controller
+++ b/Big Wave prototype/Assets/Animation/SURF/Animation_surf.controller
@@ -74,7 +74,7 @@ AnimatorStateTransition:
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 0
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-4349197344517219767
 AnimatorState:
   serializedVersion: 6
@@ -204,7 +204,7 @@ AnimatorStateTransition:
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 0
+  m_CanTransitionToSelf: 1
 --- !u!1107 &-103859826628159187
 AnimatorStateMachine:
   serializedVersion: 6

--- a/Big Wave prototype/Assets/InputActions.inputactions
+++ b/Big Wave prototype/Assets/InputActions.inputactions
@@ -33,7 +33,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "YTrick",
+                    "name": "NorthTrick",
                     "type": "Button",
                     "id": "28c76b47-0f3d-44b4-98f5-36f0a2383653",
                     "expectedControlType": "Button",
@@ -42,7 +42,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "ATrick",
+                    "name": "SouthTrick",
                     "type": "Button",
                     "id": "fb5ee62d-7c64-4906-b62b-cedcc15d76ce",
                     "expectedControlType": "Button",
@@ -51,7 +51,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "BTrick",
+                    "name": "EastTrick",
                     "type": "Button",
                     "id": "c6f14c21-bf16-4e97-a36f-b4128cf5db13",
                     "expectedControlType": "Button",
@@ -60,7 +60,7 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "XTrick",
+                    "name": "WestTrick",
                     "type": "Button",
                     "id": "b77aa287-3015-4ab9-88a0-c84e9fe6b7c6",
                     "expectedControlType": "Button",
@@ -282,7 +282,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "YTrick",
+                    "action": "NorthTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -293,7 +293,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "YTrick",
+                    "action": "NorthTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -304,7 +304,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "YTrick",
+                    "action": "NorthTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -315,7 +315,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "ATrick",
+                    "action": "SouthTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -326,7 +326,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "ATrick",
+                    "action": "SouthTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -337,7 +337,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "ATrick",
+                    "action": "SouthTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -348,7 +348,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "BTrick",
+                    "action": "EastTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -359,7 +359,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "BTrick",
+                    "action": "EastTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -370,7 +370,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "BTrick",
+                    "action": "EastTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -381,7 +381,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "XTrick",
+                    "action": "WestTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -392,7 +392,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "XTrick",
+                    "action": "WestTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -403,7 +403,7 @@
                     "interactions": "",
                     "processors": "",
                     "groups": "",
-                    "action": "XTrick",
+                    "action": "WestTrick",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Big Wave prototype/Assets/Prefab/Object/HomingMissile.prefab
+++ b/Big Wave prototype/Assets/Prefab/Object/HomingMissile.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 6913876349263444750}
   - component: {fileID: 2823997722644133774}
   - component: {fileID: 4011757520505780165}
-  - component: {fileID: 1150994643869723313}
   m_Layer: 0
   m_Name: Cylinder
   m_TagString: Untagged
@@ -84,29 +83,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!136 &1150994643869723313
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 411269424186460582}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
 --- !u!1 &1460528897490045849
 GameObject:
   m_ObjectHideFlags: 0
@@ -118,7 +94,6 @@ GameObject:
   - component: {fileID: 78137771409409426}
   - component: {fileID: 3362614259314178837}
   - component: {fileID: 8566667920296655566}
-  - component: {fileID: 2840930117433612296}
   m_Layer: 0
   m_Name: Sphere
   m_TagString: Untagged
@@ -191,27 +166,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &2840930117433612296
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1460528897490045849}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3498517856208074209
 GameObject:
   m_ObjectHideFlags: 0
@@ -223,7 +177,6 @@ GameObject:
   - component: {fileID: 329286605856625262}
   - component: {fileID: 4246634885827703532}
   - component: {fileID: 6805614881130429615}
-  - component: {fileID: 8743228801523834961}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -296,27 +249,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &8743228801523834961
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3498517856208074209}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3837250413709227432
 GameObject:
   m_ObjectHideFlags: 0
@@ -328,7 +260,6 @@ GameObject:
   - component: {fileID: 7477994216990216415}
   - component: {fileID: 8711932889075371215}
   - component: {fileID: 6203767865069462133}
-  - component: {fileID: 6544698401522862116}
   m_Layer: 0
   m_Name: Cube (1)
   m_TagString: Untagged
@@ -401,27 +332,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &6544698401522862116
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3837250413709227432}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5722339005086169043
 GameObject:
   m_ObjectHideFlags: 0
@@ -433,7 +343,6 @@ GameObject:
   - component: {fileID: 221767504919142256}
   - component: {fileID: 7542999965383546664}
   - component: {fileID: 1870496641547063064}
-  - component: {fileID: 1745993199144257192}
   m_Layer: 0
   m_Name: Cube (2)
   m_TagString: Untagged
@@ -506,27 +415,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &1745993199144257192
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5722339005086169043}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &7804052714597815174
 GameObject:
   m_ObjectHideFlags: 0
@@ -538,7 +426,6 @@ GameObject:
   - component: {fileID: 7377216514062594487}
   - component: {fileID: 6273833709541593411}
   - component: {fileID: 3066380969084362961}
-  - component: {fileID: 7390882383061264070}
   m_Layer: 0
   m_Name: Cube (3)
   m_TagString: Untagged
@@ -611,27 +498,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &7390882383061264070
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7804052714597815174}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8613377540000614300
 GameObject:
   m_ObjectHideFlags: 0

--- a/Big Wave prototype/Assets/Scenes/SampleScene.unity
+++ b/Big Wave prototype/Assets/Scenes/SampleScene.unity
@@ -945,6 +945,7 @@ MonoBehaviour:
   scorePerOneCritical: 30
   plusContinueBonus: 10
   scorePerOneCriticalMax: 100
+  critical: {fileID: 1244729556}
 --- !u!4 &119824062
 Transform:
   m_ObjectHideFlags: 0
@@ -1991,13 +1992,13 @@ MonoBehaviour:
       - m_Target: {fileID: 1244729579}
         m_TargetAssemblyTypeName: DamageToEnemy, Assembly-CSharp
         m_MethodName: AccumulateDamage
-        m_Mode: 4
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 100
-          m_StringArgument: 
+          m_StringArgument: Trick_1
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 1450173098}
@@ -4357,13 +4358,13 @@ MonoBehaviour:
       - m_Target: {fileID: 1244729579}
         m_TargetAssemblyTypeName: DamageToEnemy, Assembly-CSharp
         m_MethodName: AccumulateDamage
-        m_Mode: 4
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 100
-          m_StringArgument: 
+          m_StringArgument: Trick
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 1450173098}
@@ -4810,13 +4811,13 @@ MonoBehaviour:
       - m_Target: {fileID: 1244729579}
         m_TargetAssemblyTypeName: DamageToEnemy, Assembly-CSharp
         m_MethodName: AccumulateDamage
-        m_Mode: 4
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 100
-          m_StringArgument: 
+          m_StringArgument: Trick
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 1450173098}
@@ -7496,13 +7497,13 @@ MonoBehaviour:
       - m_Target: {fileID: 1244729579}
         m_TargetAssemblyTypeName: DamageToEnemy, Assembly-CSharp
         m_MethodName: AccumulateDamage
-        m_Mode: 4
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 100
-          m_StringArgument: 
+          m_StringArgument: Trick
           m_BoolArgument: 0
         m_CallState: 2
       - m_Target: {fileID: 1450173098}
@@ -7733,7 +7734,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1034766459}
         m_TargetAssemblyTypeName: ControllerOfTrick, Assembly-CSharp
-        m_MethodName: Trick_Y
+        m_MethodName: Trick_North
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -7749,7 +7750,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1034766459}
         m_TargetAssemblyTypeName: ControllerOfTrick, Assembly-CSharp
-        m_MethodName: Trick_A
+        m_MethodName: Trick_South
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -7765,7 +7766,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1034766459}
         m_TargetAssemblyTypeName: ControllerOfTrick, Assembly-CSharp
-        m_MethodName: Trick_B
+        m_MethodName: Trick_East
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -7781,7 +7782,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1034766459}
         m_TargetAssemblyTypeName: ControllerOfTrick, Assembly-CSharp
-        m_MethodName: Trick_X
+        m_MethodName: Trick_West
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -9655,10 +9656,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   feverEffect: {fileID: 1450010173}
   feverTime: 20
-  powerUpBuff:
-    powerUp_GrowthRate: 2
-  chargeTrickBuff:
-    chargeTrick_GrowthRate: 2
   player_FeverPoint: {fileID: 1244729563}
 --- !u!114 &1244729556
 MonoBehaviour:
@@ -9672,8 +9669,25 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a072d1b805d3e0448b85ea7cd13ae55, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  criticalRate: 4
-  criticalSound: {fileID: 8300000, guid: 24706dcbb6e711a49acb12f3b45d10f1, type: 3}
+  criticalEvents:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1778482265}
+        m_TargetAssemblyTypeName: UnityEngine.AudioSource, UnityEngine
+        m_MethodName: PlayOneShot
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 8300000, guid: 24706dcbb6e711a49acb12f3b45d10f1, type: 3}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  notCriticalEvents:
+    m_PersistentCalls:
+      m_Calls: []
+  pushedButton_CurrentTrickPattern: {fileID: 1244729568}
   criticalTrickCount: {fileID: 119824061}
   audioSource: {fileID: 1778482265}
   player_TrickPoint: {fileID: 1244729564}
@@ -9720,6 +9734,42 @@ MonoBehaviour:
   eventsWhenTrick:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 1244729556}
+        m_TargetAssemblyTypeName: Critical, Assembly-CSharp
+        m_MethodName: SetCriticalNow
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1244729565}
+        m_TargetAssemblyTypeName: CountTrickWhileJump, Assembly-CSharp
+        m_MethodName: AddTrickCount
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1244729557}
+        m_TargetAssemblyTypeName: CountTrickCombo, Assembly-CSharp
+        m_MethodName: AddCombo
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 1244729568}
         m_TargetAssemblyTypeName: PushedButton_CurrentTrickPattern, Assembly-CSharp
         m_MethodName: TrickEffect
@@ -9735,18 +9785,6 @@ MonoBehaviour:
       - m_Target: {fileID: 1034766461}
         m_TargetAssemblyTypeName: ControllerVibeOfTrick, Assembly-CSharp
         m_MethodName: Vibe
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1244729565}
-        m_TargetAssemblyTypeName: CountTrickWhileJump, Assembly-CSharp
-        m_MethodName: AddTrickCount
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -9780,18 +9818,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 1244729557}
-        m_TargetAssemblyTypeName: CountTrickCombo, Assembly-CSharp
-        m_MethodName: AddCombo
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 1244729559}
         m_TargetAssemblyTypeName: HoverJump, Assembly-CSharp
         m_MethodName: HoverJumpTrigger
@@ -9816,9 +9842,21 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  pushedButton_TrickPattern: {fileID: 1244729568}
+      - m_Target: {fileID: 119824061}
+        m_TargetAssemblyTypeName: Score_CriticalTrickCount, Assembly-CSharp
+        m_MethodName: AddScoreWhenCritical
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   judgeJumpNow: {fileID: 1244729571}
   player_TrickPoint: {fileID: 1244729564}
+  pushedButton_TrickPattern: {fileID: 1244729568}
 --- !u!114 &1244729562
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9923,6 +9961,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6f0c6045ac2b3854ea561d48370b0968, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  chargeTrickGrowthRate_Fever: 2
   changeChargeRateTheChargers: {fileID: 1244729575}
   feverMode: {fileID: 1244729544}
   player_TrickPoint: {fileID: 1244729564}
@@ -10156,6 +10195,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 614e4cbe2761a42408c1a20890eda450, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  defaultDamageAmount: 100
+  damageGrowthRate_Fever: 2
+  damageGrowthRate_Critical: 4
   feverMode: {fileID: 1244729544}
   critical: {fileID: 1244729556}
   pushedButton_CurrentTrickPattern: {fileID: 1244729568}

--- a/Big Wave prototype/Assets/Scenes/SampleScene.unity
+++ b/Big Wave prototype/Assets/Scenes/SampleScene.unity
@@ -9734,42 +9734,6 @@ MonoBehaviour:
   eventsWhenTrick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1244729556}
-        m_TargetAssemblyTypeName: Critical, Assembly-CSharp
-        m_MethodName: SetCriticalNow
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1244729565}
-        m_TargetAssemblyTypeName: CountTrickWhileJump, Assembly-CSharp
-        m_MethodName: AddTrickCount
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1244729557}
-        m_TargetAssemblyTypeName: CountTrickCombo, Assembly-CSharp
-        m_MethodName: AddCombo
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 1244729568}
         m_TargetAssemblyTypeName: PushedButton_CurrentTrickPattern, Assembly-CSharp
         m_MethodName: TrickEffect
@@ -9857,6 +9821,9 @@ MonoBehaviour:
   judgeJumpNow: {fileID: 1244729571}
   player_TrickPoint: {fileID: 1244729564}
   pushedButton_TrickPattern: {fileID: 1244729568}
+  critical: {fileID: 1244729556}
+  countTrickCombo: {fileID: 1244729557}
+  countTrickWhileJump: {fileID: 1244729565}
 --- !u!114 &1244729562
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Big Wave prototype/Assets/Script/ControllerScript/Trick-related/ControllerOfTrick.cs
+++ b/Big Wave prototype/Assets/Script/ControllerScript/Trick-related/ControllerOfTrick.cs
@@ -16,33 +16,27 @@ public class ControllerOfTrick : MonoBehaviour
         pushedButton_TrickPattern = GameObject.FindWithTag("Player").GetComponent<PushedButton_CurrentTrickPattern>();
     }
 
-    void Trick_Process(TrickButton button)
-    {
-        pushedButton_TrickPattern.SetTrickPattern(button);//押されたボタンの種類を設定
-        trick.TrickTrigger();//トリック
-    }
-
-    public void Trick_Y(InputAction.CallbackContext context)
+    public void Trick_North(InputAction.CallbackContext context)
     {
         if (!context.performed) return;
-        Trick_Process(TrickButton.north);
+        trick.TrickTrigger(TrickButton.north);//トリック
     }
 
-    public void Trick_X(InputAction.CallbackContext context)
+    public void Trick_West(InputAction.CallbackContext context)
     {
         if (!context.performed) return;
-        Trick_Process(TrickButton.west);
+        trick.TrickTrigger(TrickButton.west);//トリック
     }
 
-    public void Trick_B(InputAction.CallbackContext context)
+    public void Trick_East(InputAction.CallbackContext context)
     {
         if (!context.performed) return;
-        Trick_Process(TrickButton.east);
+        trick.TrickTrigger(TrickButton.east);//トリック
     }
 
-    public void Trick_A(InputAction.CallbackContext context)
+    public void Trick_South(InputAction.CallbackContext context)
     {
         if (!context.performed) return;
-        Trick_Process(TrickButton.south);
+        trick.TrickTrigger(TrickButton.south);//トリック
     }
 }

--- a/Big Wave prototype/Assets/Script/EnumScript.meta
+++ b/Big Wave prototype/Assets/Script/EnumScript.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b73f5aa5646e7b49b19435f0fdbf326
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Big Wave prototype/Assets/Script/EnumScript/TrickButton_Enum.cs
+++ b/Big Wave prototype/Assets/Script/EnumScript/TrickButton_Enum.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//作成者:杉山
+//トリックのボタンの種類(enum型)
+[System.Serializable]
+public enum TrickButton
+{
+    south,
+    east,
+    west,
+    north
+}

--- a/Big Wave prototype/Assets/Script/EnumScript/TrickButton_Enum.cs.meta
+++ b/Big Wave prototype/Assets/Script/EnumScript/TrickButton_Enum.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e139285dbb6bc04eb1c6182a0a3dc21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Big Wave prototype/Assets/Script/PlayerScript/ChargeTirck-related/ChargeTrickPoint.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/ChargeTirck-related/ChargeTrickPoint.cs
@@ -7,12 +7,17 @@ using UnityEngine;
 //トリックのチャージ
 public class ChargeTrickPoint : MonoBehaviour
 {
+    [Header("フィーバー状態のチャージトリック量アップの増加率")]
+    [SerializeField] float chargeTrickGrowthRate_Fever;
+
     [Header("必要なコンポーネント")]
     [SerializeField] ChangeChargeRateTheChargers changeChargeRateTheChargers;
     [SerializeField] FeverMode feverMode;
     [SerializeField] TrickPoint player_TrickPoint;
     [SerializeField] JudgeChargeTrickPointNow judgeChargeTrickPointNow;
     [SerializeField] ChangeChargeRateTheSurfer changeChargeRateTheSurfer;
+
+    const float chargeTrickGrowthRate_Normal = 1;//等倍(チャージトリック量アップの増加率)
     private bool chargeStandby = false;//これがtrueになっている時かつ波に触れている時のみトリックをチャージできる
 
     /////private(別クラスは使用不可)のメソッド/////
@@ -20,7 +25,7 @@ public class ChargeTrickPoint : MonoBehaviour
     float ChargeTrickAmount(float chargeAmount)//チャージされるトリック量
     {
         float ret = chargeAmount;//通常時のチャージされるトリック量
-        ret *= feverMode.CurrentChargeTrick_GrowthRate;//フィーバー状態のチャージ倍率
+        ret *= feverMode.FeverNow ? chargeTrickGrowthRate_Fever : chargeTrickGrowthRate_Normal;//フィーバー状態のチャージ倍率
         ret *= changeChargeRateTheChargers.ChargeRate(player_TrickPoint.MaxCount,player_TrickPoint.TrickGaugeNum);//満タンのトリックゲージの数によるチャージ倍率
         ret *= changeChargeRateTheSurfer.ChargeRate();//波に乗っている時間によるチャージ倍率
         return ret;

--- a/Big Wave prototype/Assets/Script/PlayerScript/DamageToEnemy.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/DamageToEnemy.cs
@@ -6,11 +6,20 @@ using UnityEngine;
 //敵にダメージを与える
 public class DamageToEnemy : MonoBehaviour
 {
-    HP enemy_Hp;
+    [Header("基本ダメージ量")]
+    [SerializeField] float defaultDamageAmount;//基本ダメージ量
+    [Header("フィーバーモード時のダメージの増加率")]
+    [SerializeField] float damageGrowthRate_Fever;//フィーバーモード時のダメージ増加率
+    [Header("クリティカル時のダメージの増加率")]
+    [SerializeField] float damageGrowthRate_Critical;//クリティカル時のダメージ増加率
+
     [Header("必要なコンポーネント")]
     [SerializeField] FeverMode feverMode;
     [SerializeField] Critical critical;
     [SerializeField] PushedButton_CurrentTrickPattern pushedButton_CurrentTrickPattern;
+
+    const float damageGrowthRate_Normal=1;//等倍(ダメージ増加率)
+    HP enemy_Hp;
     Queue<float> damageQueue = new Queue<float>();
 
     void Start()
@@ -18,12 +27,12 @@ public class DamageToEnemy : MonoBehaviour
         enemy_Hp = GameObject.FindWithTag("Enemy").GetComponent<HP>();
     }
 
-    public void AccumulateDamage(float defaultDamage)//ダメージをキューに蓄積
+    public void AccumulateDamage()//ダメージをキューに蓄積
     {
         //ダメージ計算
-        float damage = defaultDamage;//基本ダメージ(押されたボタンに対応した現在のトリックパターンから取得)
-        damage *= feverMode.CurrentPowerUp_GrowthRate;//フィーバーモードのダメージ加算
-        damage *= critical.CriticalDamageRate(pushedButton_CurrentTrickPattern.PushedButton);//クリティカルダメージの加算
+        float damage = defaultDamageAmount;//基本ダメージ
+        damage *= feverMode.FeverNow?damageGrowthRate_Fever:damageGrowthRate_Normal;//フィーバーモードのダメージ加算
+        damage *= critical.CriticalNow?damageGrowthRate_Critical:damageGrowthRate_Normal;//クリティカルダメージの加算
         //キューにダメージを登録
         damageQueue.Enqueue(damage);
     }

--- a/Big Wave prototype/Assets/Script/PlayerScript/FeverMode-related/FeverMode.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/FeverMode-related/FeverMode.cs
@@ -12,25 +12,10 @@ public class FeverMode : MonoBehaviour
     [SerializeField] float feverTime=20f;//フィーバー状態の効果時間
     private float remainingFeverTime = 0f;//フィーバー状態の残り効果時間
 
-    [Header("攻撃力アップのバフ")]
-    [SerializeField] PowerUpBuff powerUpBuff;//攻撃力アップのバフ
-    [Header("チャージトリック量アップのバフ")]
-    [SerializeField] ChargeTrickBuff chargeTrickBuff;//攻撃力アップのバフ
-
     [Header("必要なコンポーネント")]
     [SerializeField] FeverPoint player_FeverPoint;
 
     private bool feverNow=false;//今フィーバー状態か
-
-    public float CurrentPowerUp_GrowthRate
-    {
-        get { return powerUpBuff.CurrentPowerUp_GrowthRate; }
-    }
-
-    public float CurrentChargeTrick_GrowthRate
-    {
-        get { return chargeTrickBuff.CurrentChargeTrick_GrowthRate; }
-    }
 
     public bool FeverNow
     {
@@ -81,7 +66,6 @@ public class FeverMode : MonoBehaviour
     void FeverModeEffect()
     {
         //フィーバー状態中は...
-        //攻撃力とチャージトリック量がアップする
         //エフェクトが付く
         //フィーバーポイントが時間ごとに減っていく(フィーバー状態の残り時間を表している)
         if (feverNow)
@@ -90,62 +74,6 @@ public class FeverMode : MonoBehaviour
             player_FeverPoint.FeverPoint_ = player_FeverPoint.FeverPointMax * ratio;
         }
 
-        powerUpBuff.ChangePowerUpGrowthRate(feverNow);//フィーバー時攻撃力が上がる
-        chargeTrickBuff.ChangeChargeTrickGrowthRate(feverNow);//フィーバー時チャージトリック量が上がる
         feverEffect.SetActive(feverNow);//フィーバー時エフェクトを表示
-    }
-
-
-
-    /////内部クラス/////
-
-    [System.Serializable]
-    class PowerUpBuff
-    {
-        [Header("フィーバー状態の攻撃力アップの増加率")]
-        [SerializeField] float powerUp_GrowthRate = 1f;//フィーバー状態の攻撃力アップの増加率
-        private float currentPowerUp_GrowthRate = 1f;//現在のフィーバー状態の攻撃力アップの増加率
-
-        public float CurrentPowerUp_GrowthRate
-        {
-            get { return currentPowerUp_GrowthRate; }
-        }
-
-        public void ChangePowerUpGrowthRate(bool feverNow)//攻撃力アップの増加率を変化させる
-        {
-            if(feverNow)//フィーバー中
-            {
-                currentPowerUp_GrowthRate = powerUp_GrowthRate;
-            }
-            else
-            {
-                currentPowerUp_GrowthRate = 1f;
-            }
-        }
-    }
-
-    [System.Serializable]
-    class ChargeTrickBuff
-    {
-        [Header("フィーバー状態のチャージトリック量アップの増加率")]
-        [SerializeField] float chargeTrick_GrowthRate = 1f;//フィーバー状態のチャージトリック量アップの増加率
-        private float currentChargeTrick_GrowthRate = 1f;//現在のフィーバー状態のチャージトリック量アップの増加率
-
-        public float CurrentChargeTrick_GrowthRate
-        {
-            get { return currentChargeTrick_GrowthRate; }
-        }
-
-        public void ChangeChargeTrickGrowthRate(bool feverNow)//チャージトリック量アップの増加率を変化させる
-        {
-            if (feverNow)//フィーバー中
-            {
-                currentChargeTrick_GrowthRate = chargeTrick_GrowthRate;
-            }
-            else
-            {
-                currentChargeTrick_GrowthRate = 1f;
-            }
-        }
     }
 }

--- a/Big Wave prototype/Assets/Script/PlayerScript/GenerateEffectAlongWay.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/GenerateEffectAlongWay.cs
@@ -41,7 +41,7 @@ public class GenerateEffectAlongWay : MonoBehaviour
 
                 Instantiate(effect, passPos.position, passPos.rotation, passPos);//¶¬
 
-                if (isLastPoint) landEvents.Invoke();//’…’e‚É“o˜^‚µ‚Ä‚¢‚½ƒCƒxƒ“ƒg‚ğŒÄ‚Ño‚·
+                if (isLastPoint) landEvents.Invoke();//’…’e‚È‚ç’…’e‚É“o˜^‚µ‚Ä‚¢‚½ƒCƒxƒ“ƒg‚ğŒÄ‚Ño‚·
 
                 generatePosList[i].TransitNextPos();//Ÿ‚ÌêŠ‚ğİ’è
             }

--- a/Big Wave prototype/Assets/Script/PlayerScript/Status-related/FeverPoint.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/Status-related/FeverPoint.cs
@@ -13,7 +13,11 @@ public class FeverPoint : MonoBehaviour
     public float FeverPoint_
     {
         get { return feverPoint; }
-        set { feverPoint = value; }
+        set
+        {
+            feverPoint = value;
+            feverPoint = Mathf.Clamp(feverPoint, 0f, feverPointMax);//フィーバーポイントが限界突破しないように
+        }
     }
 
     public float FeverPointMax
@@ -24,11 +28,5 @@ public class FeverPoint : MonoBehaviour
     void Start()
     {
         feverPoint = 0f;
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        feverPoint = Mathf.Clamp(feverPoint, 0f, feverPointMax);//フィーバーポイントが限界突破しないように
     }
 }

--- a/Big Wave prototype/Assets/Script/PlayerScript/Trick-related/Critical.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/Trick-related/Critical.cs
@@ -41,7 +41,7 @@ public class Critical : MonoBehaviour
         }
     }
 
-    public void SetCriticalNow()//クリティカルが発生したかを設定
+    public void SetCriticalNow()//クリティカルが発生したかを設定(押されたボタンからクリティカルの判定)
     {
         //入力したボタンが指定されていたボタンだった時(クリティカルの時)
         if(pushedButton_CurrentTrickPattern.PushedButton == criticalButton[0])

--- a/Big Wave prototype/Assets/Script/PlayerScript/Trick-related/Trick.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/Trick-related/Trick.cs
@@ -18,13 +18,9 @@ public partial class Trick : MonoBehaviour
     [SerializeField] JudgeJumpNow judgeJumpNow;
     [SerializeField] TrickPoint player_TrickPoint;
     [SerializeField] PushedButton_CurrentTrickPattern pushedButton_TrickPattern;
-    //[SerializeField] CountTrickCombo countTrickCombo;
-    //[SerializeField] CountTrickWhileJump countTrickWhileJump;
-    //[SerializeField] ControllerVibeOfTrick controllerVibeOfTrick;
-    //[SerializeField] ChargeFeverPointWhenTrick chargeFeverPointWhenTrick;
-    //[SerializeField] Score_TrickCount score_TrickCount;
-    //[SerializeField] HoverJump hoverJump;
-    //[SerializeField] GenerateEffectAlongWay generateEffectAlongWay;
+    [SerializeField] Critical critical;
+    [SerializeField] CountTrickCombo countTrickCombo;
+    [SerializeField] CountTrickWhileJump countTrickWhileJump;
 
     HP enemy_Hp;
     
@@ -43,22 +39,12 @@ public partial class Trick : MonoBehaviour
 
         if (JudgeSuccessOfTrick())//トリック成功時
         {
+            critical.SetCriticalNow();//押されたボタンからクリティカルの判定
+            countTrickWhileJump.AddTrickCount();//ジャンプ中のトリック回数の加算
+            countTrickCombo.AddCombo();//トリックコンボ回数の加算
             eventsWhenTrick.Invoke();//登録された全イベントを呼ぶ
-            //EventsWhwnTrick();
         }
     }
-
-    //void EventsWhwnTrick()//トリック時の処理(イベント)
-    //{
-    //    countTrickWhileJump.AddTrickCount();//ジャンプ中のトリック回数の加算
-    //    countTrickCombo.AddCombo();//トリックコンボ回数の加算
-    //    pushedButton_TrickPattern.TrickEffect();//トリック事の効果を発動
-    //    controllerVibeOfTrick.Vibe();//トリック時のコントローラのバイブ
-    //    chargeFeverPointWhenTrick.Charge();//フィーバーポイントのチャージ
-    //    score_TrickCount.AddScore();//トリック回数のスコア加算
-    //    hoverJump.HoverJumpTrigger();//ホバージャンプさせる
-    //    generateEffectAlongWay.ActivateEffect();//ロープを伝うエフェクトを生成する
-    //}
 
     bool JudgeSuccessOfTrick()//トリック成功かの判定(成功であればtrueを返す)
     {

--- a/Big Wave prototype/Assets/Script/PlayerScript/Trick-related/Trick.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/Trick-related/Trick.cs
@@ -15,9 +15,17 @@ public partial class Trick : MonoBehaviour
     [Header("トリック時の処理(メソッド)")]
     [SerializeField] UnityEvent eventsWhenTrick;//トリック時の処理(メソッド)
     [Header("必要なコンポーネント")]
-    [SerializeField] PushedButton_CurrentTrickPattern pushedButton_TrickPattern;
     [SerializeField] JudgeJumpNow judgeJumpNow;
     [SerializeField] TrickPoint player_TrickPoint;
+    [SerializeField] PushedButton_CurrentTrickPattern pushedButton_TrickPattern;
+    //[SerializeField] CountTrickCombo countTrickCombo;
+    //[SerializeField] CountTrickWhileJump countTrickWhileJump;
+    //[SerializeField] ControllerVibeOfTrick controllerVibeOfTrick;
+    //[SerializeField] ChargeFeverPointWhenTrick chargeFeverPointWhenTrick;
+    //[SerializeField] Score_TrickCount score_TrickCount;
+    //[SerializeField] HoverJump hoverJump;
+    //[SerializeField] GenerateEffectAlongWay generateEffectAlongWay;
+
     HP enemy_Hp;
     
     
@@ -29,13 +37,28 @@ public partial class Trick : MonoBehaviour
     }
 
     //トリック発動
-    public void TrickTrigger()
+    public void TrickTrigger(TrickButton button)
     {
-        if(JudgeSuccessOfTrick())//トリック成功時
+        pushedButton_TrickPattern.SetTrickPattern(button);//押されたボタンの種類を設定
+
+        if (JudgeSuccessOfTrick())//トリック成功時
         {
             eventsWhenTrick.Invoke();//登録された全イベントを呼ぶ
+            //EventsWhwnTrick();
         }
     }
+
+    //void EventsWhwnTrick()//トリック時の処理(イベント)
+    //{
+    //    countTrickWhileJump.AddTrickCount();//ジャンプ中のトリック回数の加算
+    //    countTrickCombo.AddCombo();//トリックコンボ回数の加算
+    //    pushedButton_TrickPattern.TrickEffect();//トリック事の効果を発動
+    //    controllerVibeOfTrick.Vibe();//トリック時のコントローラのバイブ
+    //    chargeFeverPointWhenTrick.Charge();//フィーバーポイントのチャージ
+    //    score_TrickCount.AddScore();//トリック回数のスコア加算
+    //    hoverJump.HoverJumpTrigger();//ホバージャンプさせる
+    //    generateEffectAlongWay.ActivateEffect();//ロープを伝うエフェクトを生成する
+    //}
 
     bool JudgeSuccessOfTrick()//トリック成功かの判定(成功であればtrueを返す)
     {

--- a/Big Wave prototype/Assets/Script/PlayerScript/TrickPatternEffect.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/TrickPatternEffect.cs
@@ -4,15 +4,7 @@ using UnityEngine;
 using UnityEngine.Events;
 
 //作成者:杉山
-//トリックパターンの抽象クラス
-[System.Serializable]
-public enum TrickButton
-{
-    south,
-    east,
-    west,
-    north
-}
+//トリックごとの効果
 
 public class TrickPatternEffect : MonoBehaviour
 {

--- a/Big Wave prototype/Assets/Script/ScoreScript/Score_CriticalTrickCount.cs
+++ b/Big Wave prototype/Assets/Script/ScoreScript/Score_CriticalTrickCount.cs
@@ -12,6 +12,8 @@ public class Score_CriticalTrickCount : Score
     [Header("1回のクリティカルごとのスコア量の最大値")]
     [Tooltip("連続ボーナスで1回のクリティカルごとのスコア量が増えていきますがこの値以上は増えません")]
     [SerializeField] float scorePerOneCriticalMax;//1回のクリティカルごとのスコア量の最大値、連続ボーナスで1回のクリティカルごとのスコア量が増えていきますがこの値以上は増えません
+    [Header("必要なコンポーネント")]
+    [SerializeField] Critical critical;
     private static float score_CriticalTrickCount = 0;//クリティカル回数とクリティカル連続ボーナスのスコア
     private float currentScorePerOneCritical;//現在の1回のクリティカルごとのスコア量
 
@@ -26,17 +28,11 @@ public class Score_CriticalTrickCount : Score
         currentScorePerOneCritical = scorePerOneCritical;
     }
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
-    public void AddScoreWhenCritical(bool critical)//クリティカル時にスコアの加算をする、引数にはクリティカルだった場合はtrue、そうじゃなかったら(普通の攻撃だったら)falseを入れる
+    public void AddScoreWhenCritical()//クリティカル時にスコアの加算をする
     {
         //クリティカルを連続でするほど(クリティカル二度目から)スコア上昇量が増えていく
 
-        if(critical)//クリティカルだった
+        if(critical.CriticalNow)//クリティカルだった
         {
             score += currentScorePerOneCritical;//スコア加算
             currentScorePerOneCritical += plusContinueBonus;//現在の1回のクリティカルごとのスコア量が上がる


### PR DESCRIPTION
・一部アニメーションの修正について
サーフ君の同じトリックを連続でした時のアニメーションとクロマクロの被ダメモーションを直前の再生を打ち切って再度再生するようにしました
・クリティカルのスクリプトの修正について
Criticalコンポーネントのダメージ倍率を返すメソッドを最後に押したボタンからクリティカルの判定(bool型)を返すメソッドに変えました(ダメージ倍率はDamageToEnemyコンポーネントから変えられるようにしました)
・フィーバーモードのスクリプトの修正について
FeverModeコンポーネントのクリティカルと同様に倍率を返すメソッドを消して、今がフィーバー状態化をbool型で返すのみにしてフィーバー状態時のダメージ倍率はDamageToEnemyコンポーネント、トリックチャージ倍率はChargeTrickPointコンポーネントから変更できるようにしました。
・enum型のスクリプトの修正について
Scriptsファイルの中にEnumScriptというフォルダを作ってその中にenum型のソースコードを入れるようにします(自分で書いたコードにもまだenum型がどこかのコードに紛れている場合があるので見つけ次第EnumScriptに入れるようにします)
・ホーミングミサイルのバグ修正について
ホーミングミサイルの中のオブジェクトにコライダーがついたままだったので外しました