### PR TITLE
ジャンプ力の仕様の一部変更

### DIFF
--- a/Big Wave prototype/Assets/Scenes/SampleScene.unity
+++ b/Big Wave prototype/Assets/Scenes/SampleScene.unity
@@ -21562,7 +21562,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 192.7, y: 118.84}
+  m_AnchoredPosition: {x: 159.26, y: 118.84}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1656330841

--- a/Big Wave prototype/Assets/Scenes/SampleScene.unity
+++ b/Big Wave prototype/Assets/Scenes/SampleScene.unity
@@ -9009,7 +9009,6 @@ RectTransform:
   - {fileID: 1041760309}
   - {fileID: 1377110172}
   - {fileID: 435669033}
-  - {fileID: 1647231780}
   - {fileID: 1063896220}
   - {fileID: 200479052}
   m_Father: {fileID: 432670863}
@@ -9576,7 +9575,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1647231780}
   m_Father: {fileID: 2111325019}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -12584,7 +12584,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.15837362, y: 0, z: 0, w: 0.98737925}
+  m_LocalRotation: {x: 0.15837361, y: 0, z: 0, w: 0.9873793}
   m_LocalPosition: {x: 0, y: 9.26, z: -11.73}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -18154,7 +18154,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1308991645}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.15837362, y: 0, z: 0, w: 0.98737925}
+  m_LocalRotation: {x: 0.15837361, y: 0, z: 0, w: 0.9873793}
   m_LocalPosition: {x: 0, y: 9.26, z: -11.73}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -19074,6 +19074,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 08cdcbfe0af0b204197d7997e86f2eb2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  main_jumpPowerGauge: {fileID: 1647231779}
   jumpPowerGauge: {fileID: 1262817981}
   jumpPower: {fileID: 1017912879}
 --- !u!1 &1401361794
@@ -21551,17 +21552,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1647231779}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 44800324}
-  m_Father: {fileID: 609340865}
+  m_Father: {fileID: 647215248}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -356, y: -204}
+  m_AnchoredPosition: {x: 192.7, y: 118.84}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1656330841

--- a/Big Wave prototype/Assets/Script/PlayerScript/Jump-related/JudgeJumpable.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/Jump-related/JudgeJumpable.cs
@@ -8,6 +8,8 @@ using System;
 public class JudgeJumpable : MonoBehaviour
 {
     public event Action<bool> SwitchJumpable;//ジャンプ可能かが切り替わる瞬間に呼ぶ、trueならジャンプできるようになった時、falseならジャンプできなくなった時
+    public event Action ToJumpable;//ジャンプ可能になった時に呼ぶ
+    public event Action ToNotJumpable;//ジャンプ不可能になった時に呼ぶ
     [SerializeField] JudgeJumpNow _judgeJumpNow;
     [SerializeField] JudgeTouchWave _judgeTouchWave;
     bool _jumpableBeforeFrame = false;//前フレームのジャンプ可能状態
@@ -26,8 +28,19 @@ public class JudgeJumpable : MonoBehaviour
     {
         if(_jumpableBeforeFrame!=Jumpable)//ジャンプ可能状態が切り替わった時に切り替わりの瞬間の処理を呼ぶ
         {
-            bool switchJumpable = !_jumpableBeforeFrame ? true : false;//前フレームでジャンプ不可能であれば ジャンプ可能になったということ
+            bool switchJumpable = !_jumpableBeforeFrame;//前フレームでジャンプ不可能であれば ジャンプ可能になったということ
+
+            //ジャンプ可能状況の切り替わり時の処理を呼ぶ
             SwitchJumpable?.Invoke(switchJumpable);
+
+            if(switchJumpable)
+            {
+                ToJumpable?.Invoke();
+            }
+            else
+            {
+                ToNotJumpable?.Invoke();
+            }
         }
 
         _jumpableBeforeFrame = Jumpable;//前フレームのジャンプ可能状態の更新

--- a/Big Wave prototype/Assets/Script/PlayerScript/Jump-related/JumpPower.cs
+++ b/Big Wave prototype/Assets/Script/PlayerScript/Jump-related/JumpPower.cs
@@ -22,15 +22,13 @@ public class JumpPower : MonoBehaviour
         get
         {
             float gap=_powerMax - _powerMin;//最大ジャンプ力と最小ジャンプ力の差
-
             return _powerMin+gap*_repetitiveValue.Value;
         }
     }
 
-    public float Ratio//ジャンプ力の割合(最小なら0、最大なら1)
-    {
-        get { return _repetitiveValue.Value; }
-    }
+    public float Ratio { get { return _repetitiveValue.Value; } }//ジャンプ力の割合(最小なら0、最大なら1)
+
+    public bool ChargeNow { get { return _judgeJumpable.Jumpable && _controllerOfJump.Pushing; } }//ジャンプ力チャージ条件、ジャンプできる時かつコントローラのジャンプボタンを押し続けている時
 
     public void ResetJumpPower()//ジャンプ力のリセット、ジャンプ(操作)直後もしくはジャンプが出来なくなった直後にする
     {
@@ -40,6 +38,7 @@ public class JumpPower : MonoBehaviour
     void Start()
     {
         _repetitiveValue.ResetCycle();
+        _judgeJumpable.ToNotJumpable += ResetJumpPower;
     }
 
     void Update()
@@ -47,12 +46,9 @@ public class JumpPower : MonoBehaviour
         Charge();
     }
 
-    void Charge()
+    void Charge()//ジャンプ力のチャージ
     {
-        //ジャンプ力チャージ条件はジャンプできる時かつコントローラのジャンプボタンを押し続けている時
-        bool chargeNow = _judgeJumpable.Jumpable && _controllerOfJump.Pushing;
-
-        if (chargeNow)
+        if (ChargeNow)
         {
             _repetitiveValue.UpdateValue();
         }    

--- a/Big Wave prototype/Assets/Script/UIScript/JumpPowerDisplay/JumpPowerDisplay.cs
+++ b/Big Wave prototype/Assets/Script/UIScript/JumpPowerDisplay/JumpPowerDisplay.cs
@@ -7,19 +7,29 @@ using UnityEngine.UI;
 //ジャンプ力をUIで表示
 public class JumpPowerDisplay : MonoBehaviour
 {
-    [Header("ジャンプ力ゲージ")]
-    [SerializeField] Image jumpPowerGauge;//ジャンプ力ゲージ
+    [Header("ジャンプ力ゲージ(非チャージ時に隠す部分)")]
+    [SerializeField] GameObject main_jumpPowerGauge;//ジャンプ力ゲージ(非チャージ時に隠す部分)
+    [Header("ジャンプ力ゲージ可変部分")]
+    [SerializeField] Image jumpPowerGauge;//ジャンプ力ゲージ可変部分
     [Header("ジャンプ力")]
     [SerializeField] JumpPower jumpPower;
 
     void Update()
     {
+        Display();
         JumpPowerGauge();
     }
 
     void JumpPowerGauge()//ジャンプ力ゲージの処理
     {
+        if (!main_jumpPowerGauge.activeSelf) return;//ジャンプ力ゲージが非表示の時は以下の処理をしない
+
         float ratio = jumpPower.Ratio;
         jumpPowerGauge.fillAmount = ratio;
+    }
+
+    void Display()//チャージ中のみ表示させる
+    {
+        main_jumpPowerGauge.SetActive(jumpPower.ChargeNow);
     }
 }


### PR DESCRIPTION
ジャンプできなくなった時にジャンプ力がリセットされるようになりました
ジャンプゲージがプレイヤーを追従し、チャージしていない時はゲージが非表示になるようにしました。