### PR TITLE
SURF君の勝利時モーションのスクリプトについて修正

### DIFF
--- a/Big Wave prototype/Assets/Animation/SURF/SURF_win.fbx.meta
+++ b/Big Wave prototype/Assets/Animation/SURF/SURF_win.fbx.meta
@@ -44,7 +44,7 @@ ModelImporter:
       cycleOffset: 0
       loop: 0
       hasAdditiveReferencePose: 0
-      loopTime: 1
+      loopTime: 0
       loopBlend: 0
       loopBlendOrientation: 0
       loopBlendPositionY: 0

--- a/Big Wave prototype/Assets/Scenes/SampleScene.unity
+++ b/Big Wave prototype/Assets/Scenes/SampleScene.unity
@@ -4126,6 +4126,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _player_animator: {fileID: 1450173098}
   _deadTriggerName: Win
+  _startMotionTime: 4.5
 --- !u!1 &307558876
 GameObject:
   m_ObjectHideFlags: 0
@@ -6770,7 +6771,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 503087858}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.023613513, y: -0.0000000010750989, z: 2.5393942e-11, w: 0.99972117}
+  m_LocalRotation: {x: 0.023613513, y: 0.0000000010750989, z: -2.5393942e-11, w: 0.99972117}
   m_LocalPosition: {x: -880.46716, y: -673.2095, z: -158.42084}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -9055,7 +9056,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 623807707}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.07471572, y: -0.000000017686357, z: 0.000000001325153, w: 0.9972049}
+  m_LocalRotation: {x: 0.07471572, y: 0.000000017686357, z: -0.000000001325153, w: 0.9972049}
   m_LocalPosition: {x: -880.46716, y: -673.7095, z: -199.63083}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -13633,7 +13634,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 993304508}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.31577846, y: -0, z: -0, w: 0.948833}
+  m_LocalRotation: {x: 0.31577846, y: -0, z: -0, w: 0.9488329}
   m_LocalPosition: {x: 0.7660992, y: 13.002456, z: -8.760218}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Big Wave prototype/Assets/Script/AnimationScript/Player/PlayerWinMotion.cs
+++ b/Big Wave prototype/Assets/Script/AnimationScript/Player/PlayerWinMotion.cs
@@ -1,16 +1,40 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.Burst.CompilerServices;
 using UnityEngine;
 
-//作成者:杉山
+//作成者:杉山、桑原が一部修正
 //勝利時のプレイヤーのモーション
 public class PlayerWinMotion : MonoBehaviour
 {
     [SerializeField] Animator _player_animator;
     [SerializeField] string _deadTriggerName;
+    [Header("何秒後に勝利モーションを再生するか")]
+    [SerializeField] float _startMotionTime;
+
+    float _currentStartMotionTime = 0;
+    bool _startMotion = false;
 
     public void Trigger()
     {
-        _player_animator.SetTrigger(_deadTriggerName);
+        _startMotion = true;
+    }
+
+    void Update()
+    {
+        UpdatePlayAnimation();
+    }
+
+    void UpdatePlayAnimation()
+    {
+        if (!_startMotion) return;
+
+        _currentStartMotionTime += Time.deltaTime;
+
+        if (_currentStartMotionTime > _startMotionTime )
+        {
+            _player_animator.SetTrigger(_deadTriggerName);
+            _startMotion = false;
+        }
     }
 }


### PR DESCRIPTION
修正内容
・クロマクロ撃破時に再生される、SURF君の勝利時モーションの再生タイミングを調整できるようにしました。

・Animation->SURF_win->winのLoopTImeのチェックを外して、再生を一度のみにしました。

機能
・GamePos->Player->Component->Animation->Winから、ゲームクリア演出開始後から何秒後に勝利モーションを再生するか　
　設定できます。