### PR TITLE
プレイガイド収納時の遅延発生について修正

### DIFF
--- a/Big Wave prototype/Assets/Scenes/MenuScene.unity
+++ b/Big Wave prototype/Assets/Scenes/MenuScene.unity
@@ -276,6 +276,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 135301299}
   m_CullTransparentMesh: 1
+--- !u!1 &182126916
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 182126917}
+  m_Layer: 5
+  m_Name: MoveGuidePositions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &182126917
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 182126916}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 283969506}
+  - {fileID: 388132048}
+  m_Father: {fileID: 2013484152}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &184959399
 GameObject:
   m_ObjectHideFlags: 0
@@ -728,7 +765,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playGuideGroup: {fileID: 86869953}
-  slideSpeed: 5
+  closePosition: {fileID: 283969506}
+  showPosition: {fileID: 388132048}
+  slideSpeed: 7
 --- !u!114 &202901344
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -890,6 +929,41 @@ Transform:
   m_Children: []
   m_Father: {fileID: 2084449543}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &283969505
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 283969506}
+  m_Layer: 5
+  m_Name: ClosePos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &283969506
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 283969505}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 182126917}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 1020}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &286550864
 GameObject:
   m_ObjectHideFlags: 0
@@ -1008,6 +1082,41 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &388132047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 388132048}
+  m_Layer: 5
+  m_Name: ShowPos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &388132048
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 388132047}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 182126917}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &461821307
 GameObject:
   m_ObjectHideFlags: 0
@@ -5742,6 +5851,7 @@ RectTransform:
   - {fileID: 614956421}
   - {fileID: 86869953}
   - {fileID: 608986736}
+  - {fileID: 182126917}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Big Wave prototype/Assets/Script/UIScript/ButtonAction/PlayGuideScript/PlayGuideController.cs
+++ b/Big Wave prototype/Assets/Script/UIScript/ButtonAction/PlayGuideScript/PlayGuideController.cs
@@ -6,10 +6,12 @@ using UnityEngine.UI;
 
 public class PlayGuideController : MonoBehaviour
 {
+    [Header("必要なコンポーネント")]
     [SerializeField] MenuEffectController effectControllerObject;
     [SerializeField] PlayGuideInputHandler playGuideInputHandlerObject;
     [SerializeField] TransitionPages transitionPagesObject;
     [SerializeField] PlayGuideSlider playGuideSlider;
+    [Header("操作したい画像")]
     [SerializeField] List<Image> playGuideImages;
 
     private MenuEffectController effectController;

--- a/Big Wave prototype/Assets/Script/UIScript/ButtonAction/PlayGuideScript/PlayGuideInputHandler.cs
+++ b/Big Wave prototype/Assets/Script/UIScript/ButtonAction/PlayGuideScript/PlayGuideInputHandler.cs
@@ -23,6 +23,7 @@ public partial class PlayGuideInputHandler : MonoBehaviour
     private InputAction leftRightAction;
     private InputAction cancelAction;
     private float inputThreshould = 0.2f;
+    private bool isHolding = false;
 
     private void Awake()
     {
@@ -57,12 +58,20 @@ public partial class PlayGuideInputHandler : MonoBehaviour
 
         if (Mathf.Abs(xValue) > inputThreshould)
         {
+            if (isHolding)
+                return;
+
+            isHolding = true;
+
             if (xValue < 0)
                 leftEvent.Invoke();
 
             else if (xValue > 0)
                 rightEvent.Invoke();
         }
+
+        else
+            isHolding = false;
     }
 
     public void OnCancelInput(InputAction.CallbackContext context)//ƒLƒƒƒ“ƒZƒ‹“ü—Í‚Ìˆ—

--- a/Big Wave prototype/Assets/Script/UIScript/ButtonAction/PlayGuideScript/PlayGuideSlider.cs
+++ b/Big Wave prototype/Assets/Script/UIScript/ButtonAction/PlayGuideScript/PlayGuideSlider.cs
@@ -4,8 +4,14 @@ using UnityEngine;
 
 public class PlayGuideSlider : MonoBehaviour
 {
+    [Header("スライドさせたい画像グループ")]
     [SerializeField] RectTransform playGuideGroup;//スライドさせたい画像のグループ
-    [SerializeField] float slideSpeed = 5f;//スライド速度
+    [Header("画像格納時の位置設定用オブジェクト")]
+    [SerializeField] RectTransform closePosition;//画像格納時の位置
+    [Header("画像表示時の位置設定用オブジェクト")]
+    [SerializeField] RectTransform showPosition;//画像表示時の位置
+    [Header("スライドの速さ")]
+    [SerializeField] float slideSpeed = 8f;//スライド速度    
 
     private Vector2 offScreenPosition;//画面外待機位置
     private Vector2 onScreenPosition;//画面内画像表示位置
@@ -13,23 +19,16 @@ public class PlayGuideSlider : MonoBehaviour
     private bool isDisplay = false;//表示しているか
     private bool startSlidingIn = false;//スライドインしているか
     private bool startSlidingOut = false;//スライドアウトしているか
+    private float distance = 1.25f;
 
     public bool CompletedSlideOut { get; set; } = false;//スライドアウトが完了したか
-
-    public bool IsSliding
-    {
-        get { return isSliding; }
-    }
-
-    public bool IsDisplay
-    {
-        get { return isDisplay; }
-    }
+    public bool IsSliding { get { return isSliding; } }
+    public bool IsDisplay { get { return isDisplay; } }
 
     private void Start()
     {
-        offScreenPosition = new Vector2(0, Screen.height);//画面外待機位置の設定
-        onScreenPosition = playGuideGroup.anchoredPosition;//画面内表示位置の設定
+        offScreenPosition = closePosition.anchoredPosition;//画面外待機位置の設定
+        onScreenPosition = showPosition.anchoredPosition;//画面内表示位置の設定
         playGuideGroup.anchoredPosition = offScreenPosition;//初期位置の設定
     }
 
@@ -40,16 +39,15 @@ public class PlayGuideSlider : MonoBehaviour
         Vector2 targetPosition = startSlidingIn ? onScreenPosition : offScreenPosition;//スライド方向に応じた目標位置の設定
         playGuideGroup.anchoredPosition = Vector2.Lerp(playGuideGroup.anchoredPosition, targetPosition, slideSpeed * Time.deltaTime);
 
-        if (Vector2.Distance(playGuideGroup.anchoredPosition, targetPosition) < 0.1f)//目標の位置と現在位置の差が一定値以下なら
-        {
+        if (Vector2.Distance(playGuideGroup.anchoredPosition, targetPosition) < distance)//目標の位置と現在位置の差が一定値以下なら
             CompleteSlide();//スライド完了時の処理
-        }
     }
 
     public void SlideIn()
     {
         if (!IsDisplay)//画像が表示されていないなら
         {
+            playGuideGroup.gameObject.SetActive(true);
             startSlidingIn = true;//スライドインしている
             isSliding = true;//画像をスライドしている
         }
@@ -77,6 +75,7 @@ public class PlayGuideSlider : MonoBehaviour
 
         else if (startSlidingOut)//スライドアウト時の処理
         {
+            playGuideGroup.gameObject.SetActive(false);
             startSlidingOut = false;//スライドアウトしていない
             isDisplay = false;//画像を表示していない
             CompletedSlideOut = true;//スライドアウトが完了した


### PR DESCRIPTION
・プレイガイドを閉じた後、操作可能になるまで時間がかかってしまう不具合を修正しました。
・コントローラーのスティック操作時に、一度スティックを倒すと連続してページが移行してしまう不具合を修正しました。