### PR TITLE
ビルドしたゲームでゲーム終了時にプログラムが止まってしまうバグの修正

### DIFF
--- a/Big Wave prototype/Assets/Scenes/MenuScene.unity
+++ b/Big Wave prototype/Assets/Scenes/MenuScene.unity
@@ -4629,22 +4629,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _fadeOut: {fileID: 0}
-  _waitTime: 0.5
+  _waitTime: 0.3
   _event:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 473906928}
-        m_TargetAssemblyTypeName: MovieReset, Assembly-CSharp
-        m_MethodName: ResetMovie
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 1552875808}
         m_TargetAssemblyTypeName: SceneController, Assembly-CSharp
         m_MethodName: EndGame


### PR DESCRIPTION
原因はゲーム終了ボタンに登録されていた動画のリセット処理でした